### PR TITLE
updating install to use releases.hasicorp.com and version 0.6.1

### DIFF
--- a/consul/defaults.yaml
+++ b/consul/defaults.yaml
@@ -1,12 +1,12 @@
 consul:
-  version: 0.5.2
-  hash: b3ae610c670fc3b81737d44724ebde969da66ebf
+  version: 0.6.1
+  hash: dbb3c348fdb7cdfc03e5617956b243c594a399733afee323e69ef664cdadb1ac
 
-  ui_version: 0.5.2
-  ui_hash: 67a2665e3c6aa6ca95c24d6176641010a1002cd6
+  ui_version: 0.6.1
+  ui_hash: afccdd540b166b778c7c0483becc5e282bbbb1ee52335bfe94bf757df8c55efc
 
-  template_version: 0.11.0
-  template_hash: 4db740e15f04651f296ee81413f9bef82bab6eb2
+  template_version: 0.12.1
+  template_hash: 693c52a2b1aed9b63584f47c377efd0fc349df3616985a0709246faaf9a80c8e
 
   service: false
   config:

--- a/consul/install.sls
+++ b/consul/install.sls
@@ -43,14 +43,14 @@ consul-data-dir:
 # Install agent
 consul-download:
   file.managed:
-    - name: /tmp/{{ consul.version }}_linux_amd64.zip
-    - source: https://dl.bintray.com/mitchellh/consul/{{ consul.version }}_linux_amd64.zip
-    - source_hash: sha1={{ consul.hash }}
+    - name: /tmp/consul_{{ consul.version }}_linux_amd64.zip
+    - source: https://releases.hashicorp.com/consul/{{ consul.version }}/consul_{{ consul.version }}_linux_amd64.zip
+    - source_hash: sha256={{ consul.hash }}
     - unless: test -f /usr/local/bin/consul-{{ consul.version }}
 
 consul-extract:
   cmd.wait:
-    - name: unzip /tmp/{{ consul.version }}_linux_amd64.zip -d /tmp
+    - name: unzip /tmp/consul_{{ consul.version }}_linux_amd64.zip -d /tmp
     - watch:
       - file: consul-download
 
@@ -65,7 +65,7 @@ consul-install:
 
 consul-clean:
   file.absent:
-    - name: /tmp/{{ consul.version }}_linux_amd64.zip
+    - name: /tmp/consul_{{ consul.version }}_linux_amd64.zip
     - watch:
       - file: consul-install
 
@@ -79,14 +79,14 @@ consul-link:
 # Install UI
 consul-ui-download:
   file.managed:
-    - name: /tmp/{{ consul.ui_version }}_web_ui.zip
-    - source: https://dl.bintray.com/mitchellh/consul/{{ consul.ui_version }}_web_ui.zip
-    - source_hash: sha1={{ consul.ui_hash }}
+    - name: /tmp/consul_{{ consul.ui_version }}_web_ui.zip
+    - source: https://releases.hashicorp.com/consul/{{ consul.version }}/consul_{{ consul.ui_version }}_web_ui.zip
+    - source_hash: sha256={{ consul.ui_hash }}
     - unless: test -d /usr/local/share/consul/ui-{{ consul.ui_version }}
 
 consul-ui-extract:
   cmd.wait:
-    - name: unzip /tmp/{{ consul.ui_version }}_web_ui.zip -d /tmp/
+    - name: unzip /tmp/consul_{{ consul.ui_version }}_web_ui.zip -d /tmp/dist
     - watch:
       - file: consul-ui-download
 
@@ -101,7 +101,7 @@ consul-ui-install:
 
 consul-ui-clean:
   file.absent:
-    - name: /tmp/{{ consul.ui_version }}_web_ui.zip
+    - name: /tmp/consul_{{ consul.ui_version }}_web_ui.zip
     - watch:
       - file: consul-ui-install
 
@@ -116,8 +116,8 @@ consul-ui-link:
 consul-template-download:
   file.managed:
     - name: /tmp/consul_template_{{ consul.template_version }}_linux_amd64.zip
-    - source: https://github.com/hashicorp/consul-template/releases/download/v{{ consul.template_version }}/consul_template_{{ consul.template_version }}_linux_amd64.zip
-    - source_hash: sha1={{ consul.template_hash }}
+    - source: https://releases.hashicorp.com/consul-template/{{ consul.template_version }}/consul-template_{{ consul.template_version }}_linux_amd64.zip
+    - source_hash: sha256={{ consul.template_hash }}
     - unless: test -f /usr/local/bin/consul-template-{{ consul.template_version }}
 
 consul-template-extract:


### PR DESCRIPTION
also includes using sha256 hashes as published on releases.hasicorp.com
