### PR TITLE
Enable Consul service to start at boot time

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,31 @@ Available states
 
 Installs and configures the Consul service.
 
+``consul.install``
+------------------
+
+Downloads and installs the Consul binary file.
+
+``consul.config``
+-----------------
+
+Provision the Consul configuration files and sources.
+
+``consul.service``
+------------------
+
+Adds the Consul service startup configuration or script to an operating system.
+
+To start a service during Salt run and enable it at boot time, you need to set following Pillar:
+
+.. code:: yaml
+
+    consul:
+      service: True
+
 ``consul-template``
 -------------------
 
 Installs and configures Consul template.
+
+.. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=4 sw=4 et

--- a/consul/service.sls
+++ b/consul/service.sls
@@ -1,27 +1,28 @@
-{% from "consul/map.jinja" import consul with context %}
+{%- from "consul/map.jinja" import consul with context -%}
 
-consul-init-script:
+consul-init-file:
   file.managed:
-    {% if salt['test.provider']('service') == 'systemd' %}
+    {%- if salt['test.provider']('service') == 'systemd' %}
     - source: salt://consul/files/consul.service
     - name: /etc/systemd/system/consul.service
     - mode: 0644
-    {% elif salt['test.provider']('service') == 'upstart' %}
+    {%- elif salt['test.provider']('service') == 'upstart' %}
     - source: salt://consul/files/consul.upstart
     - name: /etc/init/consul.conf
     - mode: 0644
-    {% else %}
+    {%- else %}
     - source: salt://consul/files/consul.sysvinit
     - name: /etc/init.d/consul
     - mode: 0755
-    {% endif %}
-    {% if consul.service != False %}
-    - watch_in:
-       - service: consul
-    {% endif %}
+    {%- endif %}
 
-{% if consul.service != False %}
+{%- if consul.service %}
+
 consul-service:
   service.running:
     - name: consul
-{% endif %}
+    - enable: True
+    - watch:
+      - file: consul-init-file
+
+{%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,11 +1,12 @@
 consul:
-  service: true
+  # Start Consul agent service and enable it at boot time
+  service: True
 
   config:
-    server: true
+    server: True
     bind_addr: 0.0.0.0
 
-    enable_debug: true
+    enable_debug: True
 
     datacenter: eu
 
@@ -23,14 +24,17 @@ consul:
         - script: /usr/local/share/consul/check_redis.py
           interval: 10s
   scripts:
-    - source: salt://files/consul/check_redis.py 
+    - source: salt://files/consul/check_redis.py
       name: /usr/local/share/consul/check_redis.py
 
 consul_template:
-  service: true
+  # Start consul-template daemon and enable it at boot time
+  service: True
+
   config:
     consul: 127.0.0.1:8500
     log_level: info
+
   tmpl:
     - name: example.com
       source: salt://files/example.com.ctmpl
@@ -39,3 +43,5 @@ consul_template:
           source: /etc/consul-template/tmpl-source/example.com.ctmpl
           destination: /etc/nginx/sites-enabled/example.com
           command: systemctl restart nginx
+
+# vim: ft=yaml


### PR DESCRIPTION
Hi!

This PR makes sure that if Consul service is going to be provisioned, it also will be enabled at at boot time. It's always confusing to find out that Consul is not running after machine reboot or container restart.

Also, added descriptions of `consul` sub-states to the README.
