### PR TITLE
Make running user and group configurable for Consul agent service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# VIM swap files
+*.sw?
+# Git files
+*.orig

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2013-2015 Salt Stack Formulas
+   Copyright (c) 2013-2017 Salt Stack Formulas
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/consul/config.sls
+++ b/consul/config.sls
@@ -3,41 +3,43 @@
 consul-config:
   file.managed:
     - name: /etc/consul.d/config.json
-    {% if consul.service != False %}
-    - watch_in:
-       - service: consul
-    {% endif %}
-    - user: consul
-    - group: consul
-    - require:
-      - user: consul
+    - source: salt://consul/files/config.json
+    - template: jinja
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
+    - mode: 640
     - contents: |
         {{ consul.config | json }}
+{%- if consul.service %}
+    - watch_in:
+      - service: consul
+{%- endif %}
 
-{% for script in consul.scripts %}
+{%- for script in consul.scripts %}
+
 consul-script-install-{{ loop.index }}:
   file.managed:
-    - source: {{ script.source }}
     - name: {{ script.name }}
+    - source: {{ script.source }}
     - template: jinja
-    - user: consul
-    - group: consul
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
     - mode: 0755
-{% endfor %}
+
+{%- endfor %}
 
 consul-script-config:
   file.managed:
-    - source: salt://{{ slspath }}/files/services.json
     - name: /etc/consul.d/services.json
+    - source: salt://consul/files/services.json
     - template: jinja
-    {% if consul.service != False %}
-    - watch_in:
-       - service: consul
-    {% endif %}
-    - user: consul
-    - group: consul
-    - require:
-      - user: consul
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
+    - mode: 644
     - context:
         register: |
           {{ consul.register | json }}
+{%- if consul.service %}
+    - watch_in:
+      - service: consul
+{%- endif %}

--- a/consul/config.sls
+++ b/consul/config.sls
@@ -1,10 +1,8 @@
-{% from slspath+"/map.jinja" import consul with context %}
+{%- from slspath+"/map.jinja" import consul with context -%}
 
 consul-config:
   file.managed:
     - name: /etc/consul.d/config.json
-    - source: salt://consul/files/config.json
-    - template: jinja
     - user: {{ consul.user }}
     - group: {{ consul.group }}
     - mode: 640
@@ -31,7 +29,7 @@ consul-script-install-{{ loop.index }}:
 consul-script-config:
   file.managed:
     - name: /etc/consul.d/services.json
-    - source: salt://consul/files/services.json
+    - source: salt://{{ slspath }}/files/services.json
     - template: jinja
     - user: {{ consul.user }}
     - group: {{ consul.group }}

--- a/consul/defaults.yaml
+++ b/consul/defaults.yaml
@@ -2,13 +2,16 @@ consul:
   version: 0.7.0
   download_host: releases.hashicorp.com
 
-  service: false
+  service: False
+  user: consul
+  group: consul
+
   config:
-    server: false
+    server: False
     bind_addr: 0.0.0.0
     data_dir: /var/consul
-    ui: true
-    enable_debug: false
+    ui: True
+    enable_debug: False
     log_level: info
     encrypt: ""
     retry_join: []

--- a/consul/files/consul.service
+++ b/consul/files/consul.service
@@ -1,5 +1,7 @@
+{%- from "consul/map.jinja" import consul with context -%}
+
 [Unit]
-Description=consul
+Description=Consul agent
 Wants=network.target
 After=network.target
 
@@ -8,7 +10,8 @@ Environment="GOMAXPROCS=2" "PATH=/usr/local/bin:/usr/bin:/bin"
 ExecStart=/usr/local/bin/consul agent -config-dir=/etc/consul.d
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=TERM
-User=consul
+User={{ consul.user }}
+Group={{ consul.group }}
 
 [Install]
 WantedBy=multi-user.target

--- a/consul/files/consul.sysvinit
+++ b/consul/files/consul.sysvinit
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
 # consul        Manage the consul agent
-#       
-# chkconfig:   2345 95 95
-# description: Consul is a tool for service discovery and configuration
-# processname: consul
-# config: /etc/consul.conf
-# pidfile: /var/run/consul.pid
+#
+# chkconfig:    2345 95 95
+# description:  Consul is a tool for service discovery and configuration
+# processname:  consul
+# config:       /etc/consul.d/config.json
+# pidfile:      /var/run/consul.pid
 
 ### BEGIN INIT INFO
 # Provides:       consul
@@ -24,7 +24,6 @@
 . /etc/rc.d/init.d/functions
 
 prog="consul"
-user="consul"
 exec="/usr/local/bin/$prog"
 pidfile="/var/run/$prog.pid"
 lockfile="/var/lock/subsys/$prog"
@@ -32,7 +31,12 @@ logfile="/var/log/$prog"
 confdir="/etc/consul.d"
 
 # pull in sysconfig settings
-[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+if [ -f /etc/sysconfig/$prog ]; then
+    . /etc/sysconfig/$prog
+fi
+
+user=${CONSUL_USER:-consul}
+group=${CONSUL_GROUP:-consul}
 
 export GOMAXPROCS=${GOMAXPROCS:-2}
 
@@ -44,7 +48,7 @@ start() {
     umask 077
 
     touch $logfile $pidfile
-    chown $user:$user $logfile $pidfile
+    chown "$user":"$group" $logfile $pidfile
 
     echo -n $"Starting $prog: "
     
@@ -56,7 +60,7 @@ start() {
     ## owned by consul:consul, using -pid-file results in a permission error.
     daemon \
         --pidfile=$pidfile \
-        --user=consul \
+        --user="$user" \
         " { $exec agent -config-dir=$confdir &>> $logfile & } ; echo \$! >| $pidfile "
     
     RETVAL=$?
@@ -71,7 +75,7 @@ start() {
     count=0
     ready=0
     pid=$( cat ${pidfile} )
-    while checkpid ${pid} && [ $count -lt 60 ] && [ $ready -ne 1 ]; do
+    while checkpid "${pid}" && [ $count -lt 60 ] && [ $ready -ne 1 ]; do
         count=$(( count + 1 ))
         
         if netstat -lptn | egrep -q ":8400.*LISTEN +${pid}/" ; then
@@ -108,7 +112,7 @@ stop() {
         while [ $count -lt 10 ] && [ $stopped -ne 1 ]; do
             count=$(( count + 1 ))
             
-            if ! checkpid ${pid} ; then
+            if ! checkpid "${pid}" ; then
                 stopped=1
             else
                 sleep 1

--- a/consul/files/consul.upstart
+++ b/consul/files/consul.upstart
@@ -6,19 +6,20 @@ stop on runlevel [!2345]
 respawn
 
 script
-  if [ -f "/etc/service/consul" ]; then
-    . /etc/service/consul
+  if [ -f /etc/default/consul ]; then
+    . /etc/default/consul
   fi
 
   # Make sure to use all our CPUs, because Consul can block a scheduler thread
-  export GOMAXPROCS=`nproc`
+  export GOMAXPROCS=$(nproc)
 
   # Get the public IP
-  BIND=`ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }'`
+  BIND=$(ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }')
 
-  exec start-stop-daemon --start -c consul \
+  exec start-stop-daemon --start \
+    --chuid ${CONSUL_USER:-consul}:${CONSUL_GROUP:-consul} \
     --exec /usr/local/bin/consul agent -- \
       -config-dir="/etc/consul.d" \
       ${CONSUL_FLAGS} \
-      >> /var/log/consul.log 2>&1
+        >> /var/log/consul.log 2>&1
 end script

--- a/consul/install.sls
+++ b/consul/install.sls
@@ -10,24 +10,26 @@ consul-bin-dir:
     - makedirs: True
 
 # Create consul user
-consul-user:
+consul-group:
   group.present:
-    - name: consul
+    - name: {{ consul.group }}
+
+consul-user:
   user.present:
-    - name: consul
-    - createhome: false
-    - system: true
+    - name: {{ consul.user }}
+    - createhome: False
+    - system: True
     - groups:
-      - consul
+      - {{ consul.group }}
     - require:
-      - group: consul
+      - group: consul-group
 
 # Create directories
 consul-config-dir:
   file.directory:
     - name: /etc/consul.d
-    - user: consul
-    - group: consul
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
 
 consul-data-dir:
   file.directory:

--- a/consul/install.sls
+++ b/consul/install.sls
@@ -17,10 +17,10 @@ consul-group:
 consul-user:
   user.present:
     - name: {{ consul.user }}
+    - gid: {{ consul.group }}
+    - home: {{ consul.config.data_dir }}
     - createhome: False
     - system: True
-    - groups:
-      - {{ consul.group }}
     - require:
       - group: consul-group
 

--- a/consul/service.sls
+++ b/consul/service.sls
@@ -19,16 +19,16 @@ consul-init-file:
   file.managed:
     {%- if salt['test.provider']('service') == 'systemd' %}
     - name: /etc/systemd/system/consul.service
-    - source: salt://consul/files/consul.service
+    - source: salt://{{ slspath }}/files/consul.service
     - template: jinja
     - mode: 0644
     {%- elif salt['test.provider']('service') == 'upstart' %}
     - name: /etc/init/consul.conf
-    - source: salt://consul/files/consul.upstart
+    - source: salt://{{ slspath }}/files/consul.upstart
     - mode: 0644
     {%- else %}
     - name: /etc/init.d/consul
-    - source: salt://consul/files/consul.sysvinit
+    - source: salt://{{ slspath }}/files/consul.sysvinit
     - mode: 0755
     {%- endif %}
     - user: root

--- a/consul/service.sls
+++ b/consul/service.sls
@@ -1,20 +1,38 @@
 {%- from slspath+"/map.jinja" import consul with context -%}
 
+consul-init-env:
+  file.managed:
+    {%- if grains['os_family'] == 'Debian' %}
+    - name: /etc/default/consul
+    {%- else %}
+    - name: /etc/sysconfig/consul
+    - makedirs: True
+    {%- endif %}
+    - user: root
+    - group: root
+    - mode: 0644
+    - contents:
+      - CONSUL_USER={{ consul.user }}
+      - CONSUL_GROUP={{ consul.group }}
+
 consul-init-file:
   file.managed:
     {%- if salt['test.provider']('service') == 'systemd' %}
-    - source: salt://{{ slspath }}/files/consul.service
     - name: /etc/systemd/system/consul.service
+    - source: salt://consul/files/consul.service
+    - template: jinja
     - mode: 0644
     {%- elif salt['test.provider']('service') == 'upstart' %}
-    - source: salt://{{ slspath }}/files/consul.upstart
     - name: /etc/init/consul.conf
+    - source: salt://consul/files/consul.upstart
     - mode: 0644
     {%- else %}
-    - source: salt://{{ slspath }}/files/consul.sysvinit
     - name: /etc/init.d/consul
+    - source: salt://consul/files/consul.sysvinit
     - mode: 0755
     {%- endif %}
+    - user: root
+    - group: root
 
 {%- if consul.service %}
 
@@ -23,6 +41,7 @@ consul-service:
     - name: consul
     - enable: True
     - watch:
+      - file: consul-init-env
       - file: consul-init-file
 
 {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,10 @@ consul:
   # Start Consul agent service and enable it at boot time
   service: True
 
+  # Set user and group for Consul config files and running service
+  user: consul
+  group: consul
+
   config:
     server: True
     bind_addr: 0.0.0.0


### PR DESCRIPTION
This PR allows to configure effective user and group ID under whose privileges the Consul agent will be running (and who will be able to edit config files). The previous default `consul:consul` is preserved.

The main motivation behind this change is to be able to run Consul DNS service on port 53 (or HTTP API on 80), which requires superuser capabilities, i.e.:
```yaml
# pillar/consul.sls
consul:
  service: True
  user: root
  group: root
  config:
    server: True
    ports:
      dns: 53
```

The `pillar.example` file updated accordingly.