### PR TITLE
[consul] allow rehoming

### DIFF
--- a/consul/config.sls
+++ b/consul/config.sls
@@ -1,9 +1,7 @@
-{% from "consul/map.jinja" import consul with context %}
+{% from slspath+"/map.jinja" import consul with context %}
 
 consul-config:
   file.managed:
-    - source: salt://consul/files/config.json
-    - template: jinja
     - name: /etc/consul.d/config.json
     {% if consul.service != False %}
     - watch_in:
@@ -13,6 +11,8 @@ consul-config:
     - group: consul
     - require:
       - user: consul
+    - contents: |
+        {{ consul.config | json }}
 
 {% for script in consul.scripts %}
 consul-script-install-{{ loop.index }}:
@@ -27,7 +27,7 @@ consul-script-install-{{ loop.index }}:
 
 consul-script-config:
   file.managed:
-    - source: salt://consul/files/services.json
+    - source: salt://{{ slspath }}/files/services.json
     - name: /etc/consul.d/services.json
     - template: jinja
     {% if consul.service != False %}
@@ -38,3 +38,6 @@ consul-script-config:
     - group: consul
     - require:
       - user: consul
+    - context:
+        register: |
+          {{ consul.register | json }}

--- a/consul/files/config.json
+++ b/consul/files/config.json
@@ -1,2 +1,0 @@
-{% from "consul/map.jinja" import consul with context %}
-{{ consul.config | json}}

--- a/consul/files/services.json
+++ b/consul/files/services.json
@@ -1,4 +1,3 @@
-{% from "consul/map.jinja" import consul with context %}
 {
-  "services": {{ consul.register | json }}
+  "services": {{ register }}
 }

--- a/consul/init.sls
+++ b/consul/init.sls
@@ -1,6 +1,6 @@
-{% from "consul/map.jinja" import consul with context %}
+{% from slspath+"/map.jinja" import consul with context %}
 
 include:
-  - consul.install
-  - consul.config
-  - consul.service
+  - {{ slspath }}.install
+  - {{ slspath }}.config
+  - {{ slspath }}.service

--- a/consul/install.sls
+++ b/consul/install.sls
@@ -1,4 +1,4 @@
-{% from "consul/map.jinja" import consul with context %}
+{% from slspath+"/map.jinja" import consul with context %}
 
 consul-dep-unzip:
   pkg.installed:

--- a/consul/map.jinja
+++ b/consul/map.jinja
@@ -1,4 +1,4 @@
-{% import_yaml "consul/defaults.yaml" as defaults %}
+{% import_yaml slspath+"/defaults.yaml" as defaults %}
 
 {% set consul = salt['pillar.get']('consul', default=defaults.consul, merge=True) %}
 

--- a/consul/service.sls
+++ b/consul/service.sls
@@ -1,17 +1,17 @@
-{%- from "consul/map.jinja" import consul with context -%}
+{%- from slspath+"/map.jinja" import consul with context -%}
 
 consul-init-file:
   file.managed:
     {%- if salt['test.provider']('service') == 'systemd' %}
-    - source: salt://consul/files/consul.service
+    - source: salt://{{ slspath }}/files/consul.service
     - name: /etc/systemd/system/consul.service
     - mode: 0644
     {%- elif salt['test.provider']('service') == 'upstart' %}
-    - source: salt://consul/files/consul.upstart
+    - source: salt://{{ slspath }}/files/consul.upstart
     - name: /etc/init/consul.conf
     - mode: 0644
     {%- else %}
-    - source: salt://consul/files/consul.sysvinit
+    - source: salt://{{ slspath }}/files/consul.sysvinit
     - name: /etc/init.d/consul
     - mode: 0755
     {%- endif %}


### PR DESCRIPTION
This allows me to call the formula as `consul-formula.consul`, which has the advantage of being able to pin to particular version, without needing to update `/etc/salt/master` with a new repo root for each formula, as well as avoid a naming conflict.
It also simplifies the config and service templates.