### PR TITLE
Download URL configurable via pillar

### DIFF
--- a/consul/defaults.yaml
+++ b/consul/defaults.yaml
@@ -1,6 +1,7 @@
 consul:
   version: 0.7.0
   hash: b350591af10d7d23514ebaa0565638539900cdb3aaa048f077217c4c46653dd8
+  download_host: releases.hashicorp.com
 
   service: false
   config:

--- a/consul/install.sls
+++ b/consul/install.sls
@@ -46,7 +46,7 @@ consul-data-dir:
 consul-download:
   file.managed:
     - name: /tmp/consul_{{ consul.version }}_linux_amd64.zip
-    - source: https://releases.hashicorp.com/consul/{{ consul.version }}/consul_{{ consul.version }}_linux_amd64.zip
+    - source: https://{{ consul.download_host }}/consul/{{ consul.version }}/consul_{{ consul.version }}_linux_amd64.zip
     - source_hash: sha256={{ consul.hash }}
     - unless: test -f /usr/local/bin/consul-{{ consul.version }}
 


### PR DESCRIPTION
I ran into this problem where the formula can't download and install
Consul:

https://github.com/saltstack/salt/issues/38730

As a work around, I'm making the download URL configurable. Not sure if
many other people will find this useful, so if you don't want to merge
it that's fine. For me it's only a temporary fix until I can upgrade
Salt.