### PR TITLE
Added support for installation on ARM architectures

### DIFF
--- a/consul/defaults.yaml
+++ b/consul/defaults.yaml
@@ -1,6 +1,5 @@
 consul:
   version: 0.7.0
-  hash: b350591af10d7d23514ebaa0565638539900cdb3aaa048f077217c4c46653dd8
   download_host: releases.hashicorp.com
 
   service: false

--- a/consul/install.sls
+++ b/consul/install.sls
@@ -39,14 +39,14 @@ consul-data-dir:
 # Install agent
 consul-download:
   file.managed:
-    - name: /tmp/consul_{{ consul.version }}_linux_amd64.zip
-    - source: https://{{ consul.download_host }}/consul/{{ consul.version }}/consul_{{ consul.version }}_linux_amd64.zip
-    - source_hash: sha256={{ consul.hash }}
+    - name: /tmp/consul_{{ consul.version }}_linux_{{ consul.arch }}.zip
+    - source: https://{{ consul.download_host }}/consul/{{ consul.version }}/consul_{{ consul.version }}_linux_{{ consul.arch }}.zip
+    - source_hash: https://releases.hashicorp.com/consul/{{ consul.version }}/consul_{{ consul.version }}_SHA256SUMS
     - unless: test -f /usr/local/bin/consul-{{ consul.version }}
 
 consul-extract:
   cmd.wait:
-    - name: unzip /tmp/consul_{{ consul.version }}_linux_amd64.zip -d /tmp
+    - name: unzip /tmp/consul_{{ consul.version }}_linux_{{ consul.arch }}.zip -d /tmp
     - watch:
       - file: consul-download
 
@@ -61,7 +61,7 @@ consul-install:
 
 consul-clean:
   file.absent:
-    - name: /tmp/consul_{{ consul.version }}_linux_amd64.zip
+    - name: /tmp/consul_{{ consul.version }}_linux_{{ consul.arch }}.zip
     - watch:
       - file: consul-install
 

--- a/consul/map.jinja
+++ b/consul/map.jinja
@@ -1,5 +1,22 @@
 {% import_yaml "consul/defaults.yaml" as defaults %}
 
+{## Add any overrides based on CPU architecture. ##}
+{% set cpu_arch_map = salt['grains.filter_by']({
+        'armv6l': {
+            "arch": 'arm'
+        },
+        'armv7l': {
+            "arch": 'arm'
+        },
+        'x86_64': {
+            "arch": 'amd64'
+        }
+  }
+  ,grain="cpuarch"
+  ,merge=salt['pillar.get']('consul'))
+%}
+{% do defaults.consul.update(cpu_arch_map) %}
+
 {% set consul = salt['pillar.get']('consul', default=defaults.consul, merge=True) %}
 
 {% do consul.config.update({'retry_join': consul.config.retry_join or []}) %}


### PR DESCRIPTION
I was trying to install consul on some Raspberry Pis using this formula and found out that they were hardcoded to install on amd64 architectures alone. 

Considering that Hashicorp publishes packages for ARM, I added to this formula the same bit I add to the [Nomad](https://github.com/saltstack-formulas/nomad-formula) and [golang](https://github.com/saltstack-formulas/golang-formula) formulas. 

I also replaced the hardcoded SHA256 hash by a link coming from the Hashicorp website that lists all hashes for all released packages. This way there is no need to change anything in the pillar other than the Consul version. 