### PR TITLE
Bugfix: Defaults are ignored when pillar is set

### DIFF
--- a/consul/map.jinja
+++ b/consul/map.jinja
@@ -1,5 +1,7 @@
 {% import_yaml slspath+"/defaults.yaml" as defaults %}
 
+{% set consul = salt['pillar.get']('consul', default=defaults.consul, merge=True) %}
+
 {## Add any overrides based on CPU architecture. ##}
 {% set cpu_arch_map = salt['grains.filter_by']({
         'armv6l': {
@@ -13,10 +15,9 @@
         }
   }
   ,grain="cpuarch"
-  ,merge=salt['pillar.get']('consul'))
+  ,merge=consul)
 %}
-{% do defaults.consul.update(cpu_arch_map) %}
 
-{% set consul = salt['pillar.get']('consul', default=defaults.consul, merge=True) %}
+{% do consul.update(cpu_arch_map) %}
 
 {% do consul.config.update({'retry_join': consul.config.retry_join or []}) %}

--- a/consul/map.jinja
+++ b/consul/map.jinja
@@ -3,7 +3,7 @@
 {% set consul = salt['pillar.get']('consul', default=defaults.consul, merge=True) %}
 
 {## Add any overrides based on CPU architecture. ##}
-{% set cpu_arch_map = salt['grains.filter_by']({
+{% set consul = salt['grains.filter_by']({
         'armv6l': {
             "arch": 'arm'
         },
@@ -17,7 +17,5 @@
   ,grain="cpuarch"
   ,merge=consul)
 %}
-
-{% do consul.update(cpu_arch_map) %}
 
 {% do consul.config.update({'retry_join': consul.config.retry_join or []}) %}


### PR DESCRIPTION
Current implementation has the following bug:
`cpu_arch_map` gets merged with the pillar, and the result is then used to `update` the defaults, which is then merged back into pillar.
The `update` does not result in a recursive merge, but an override of the dictionary keys.

as an example, the following files:
pillar:
```
consul:
  config:
    value: 1
```
defaults:
```
consul:
  config:
    value_2: 2
    value_3: 3
```

will result in using

```
consul:
  config:
    value: 1
```
instead of

```
consul:
  config:
    value: 1
    value_2: 2
    value_3: 3
```

This changes solves the issue