### PR TITLE
Remove services.json, no need for it anymore

### DIFF
--- a/consul/files/services.json
+++ b/consul/files/services.json
@@ -1,3 +1,0 @@
-{
-  "services": {{ register }}
-}


### PR DESCRIPTION
This PR is related to PR #21, I just forgot to remove `services.json` file since it's not needed anymore because `file.serialize` is used instead `file.manage`.

Thanks.