### PR TITLE
Allow configure user and group for Consul service

### DIFF
--- a/consul/config.sls
+++ b/consul/config.sls
@@ -21,8 +21,8 @@ consul-script-install-{{ loop.index }}:
     - name: {{ script.name }}
     - template: jinja
     - context: {{ script.get('context', {}) | yaml }}
-    - user: consul
-    - group: consul
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
     - mode: 0755
 {% endfor %}
 
@@ -33,8 +33,8 @@ consul-script-config:
     - watch_in:
        - service: consul
     {% endif %}
-    - user: consul
-    - group: consul
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
     - require:
       - user: consul
     - formatter: json

--- a/consul/defaults.yaml
+++ b/consul/defaults.yaml
@@ -3,6 +3,10 @@ consul:
   download_host: releases.hashicorp.com
 
   service: false
+
+  user: consul
+  group: consul
+
   config:
     server: false
     bind_addr: 0.0.0.0

--- a/consul/files/consul.service
+++ b/consul/files/consul.service
@@ -8,7 +8,8 @@ Environment="GOMAXPROCS=2" "PATH=/usr/local/bin:/usr/bin:/bin"
 ExecStart=/usr/local/bin/consul agent -config-dir=/etc/consul.d
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=TERM
-User=consul
+User={{ user }}
+Group={{ group }}
 
 [Install]
 WantedBy=multi-user.target

--- a/consul/files/consul.sysvinit
+++ b/consul/files/consul.sysvinit
@@ -24,7 +24,6 @@
 . /etc/rc.d/init.d/functions
 
 prog="consul"
-user="consul"
 exec="/usr/local/bin/$prog"
 pidfile="/var/run/$prog.pid"
 lockfile="/var/lock/subsys/$prog"
@@ -33,6 +32,9 @@ confdir="/etc/consul.d"
 
 # pull in sysconfig settings
 [ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+user=${CONSUL_USER:-consul}
+group=${CONSUL_GROUP:-consul}
 
 export GOMAXPROCS=${GOMAXPROCS:-2}
 
@@ -44,7 +46,7 @@ start() {
     umask 077
 
     touch $logfile $pidfile
-    chown $user:$user $logfile $pidfile
+    chown "$user:$group" $logfile $pidfile
 
     echo -n $"Starting $prog: "
     
@@ -56,7 +58,7 @@ start() {
     ## owned by consul:consul, using -pid-file results in a permission error.
     daemon \
         --pidfile=$pidfile \
-        --user=consul \
+        --user="$user" \
         " { $exec agent -config-dir=$confdir &>> $logfile & } ; echo \$! >| $pidfile "
     
     RETVAL=$?

--- a/consul/files/consul.upstart
+++ b/consul/files/consul.upstart
@@ -6,8 +6,8 @@ stop on runlevel [!2345]
 respawn
 
 script
-  if [ -f "/etc/service/consul" ]; then
-    . /etc/service/consul
+  if [ -f /etc/default/consul ]; then
+    . /etc/default/consul
   fi
 
   # Make sure to use all our CPUs, because Consul can block a scheduler thread
@@ -16,7 +16,8 @@ script
   # Get the public IP
   BIND=`ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }'`
 
-  exec start-stop-daemon --start -c consul \
+  exec start-stop-daemon --start \
+    --chuid ${CONSUL_USER:-consul}:${CONSUL_GROUP:-consul} \
     --exec /usr/local/bin/consul agent -- \
       -config-dir="/etc/consul.d" \
       ${CONSUL_FLAGS} \

--- a/consul/install.sls
+++ b/consul/install.sls
@@ -10,24 +10,25 @@ consul-bin-dir:
     - makedirs: True
 
 # Create consul user
-consul-user:
+consul-group:
   group.present:
-    - name: consul
+    - name: {{ consul.group }}
+
+consul-user:
   user.present:
-    - name: consul
-    - createhome: false
-    - system: true
-    - groups:
-      - consul
+    - name: {{ consul.user }}
+    - gid: {{ consul.group }}
+    - createhome: False
+    - system: True
     - require:
-      - group: consul
+      - group: consul-group
 
 # Create directories
 consul-config-dir:
   file.directory:
     - name: /etc/consul.d
-    - user: consul
-    - group: consul
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
 
 consul-data-dir:
   file.directory:

--- a/consul/service.sls
+++ b/consul/service.sls
@@ -1,10 +1,29 @@
 {%- from slspath+"/map.jinja" import consul with context -%}
 
+consul-init-env:
+  file.managed:
+    {%- if grains['os_family'] == 'Debian' %}
+    - name: /etc/default/consul
+    {%- else %}
+    - name: /etc/sysconfig/consul
+    - makedirs: True
+    {%- endif %}
+    - user: root
+    - group: root
+    - mode: 0644
+    - contents:
+      - CONSUL_USER={{ consul.user }}
+      - CONSUL_GROUP={{ consul.group }}
+
 consul-init-file:
   file.managed:
     {%- if salt['test.provider']('service') == 'systemd' %}
     - source: salt://{{ slspath }}/files/consul.service
     - name: /etc/systemd/system/consul.service
+    - template: jinja
+    - context:
+        user: {{ consul.user }}
+        group: {{ consul.group }}
     - mode: 0644
     {%- elif salt['test.provider']('service') == 'upstart' %}
     - source: salt://{{ slspath }}/files/consul.upstart
@@ -23,6 +42,7 @@ consul-service:
     - name: consul
     - enable: True
     - watch:
+      - file: consul-init-env
       - file: consul-init-file
 
 {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,10 @@ consul:
   # Start Consul agent service and enable it at boot time
   service: True
 
+  # Set user and group for Consul config files and running service
+  user: consul
+  group: consul
+
   config:
     server: True
     bind_addr: 0.0.0.0


### PR DESCRIPTION
This PR supersedes #14 with isolated changes related only to subj.
@AAbouZaid , please take a look. Thank you!

Effectively, this PR allows to configure effective user and group ID under whose privileges the Consul agent will be running (and who will be able to edit config files). The previous default `consul:consul` is preserved.

The main motivation behind this change is to be able to run Consul DNS service on port 53 (or HTTP API on 80), which requires superuser capabilities, i.e.:
```yaml
# pillar/consul.sls
consul:
  service: True
  user: root
  group: root
  config:
    server: True
    ports:
      dns: 53
```

The `pillar.example` file updated accordingly.