### PR TITLE
Secure filesystem permissions for config file and data dir

### DIFF
--- a/consul/config.sls
+++ b/consul/config.sls
@@ -1,18 +1,19 @@
-{% from slspath + "/map.jinja" import consul with context %}
+{%- from slspath + '/map.jinja' import consul with context -%}
 
 consul-config:
   file.serialize:
     - name: /etc/consul.d/config.json
-    {% if consul.service != False %}
-    - watch_in:
-       - service: consul
-    {% endif %}
-    - user: consul
-    - group: consul
-    - require:
-      - user: consul
     - formatter: json
     - dataset: {{ consul.config }}
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
+    - mode: 0640
+    - require:
+      - user: consul-user
+    {%- if consul.service %}
+    - watch_in:
+       - service: consul
+    {%- endif %}
 
 {% for script in consul.scripts %}
 consul-script-install-{{ loop.index }}:
@@ -36,7 +37,7 @@ consul-script-config:
     - user: {{ consul.user }}
     - group: {{ consul.group }}
     - require:
-      - user: consul
+      - user: consul-user
     - formatter: json
     - dataset:
         services: {{ consul.register }}

--- a/consul/install.sls
+++ b/consul/install.sls
@@ -1,4 +1,4 @@
-{% from slspath+"/map.jinja" import consul with context %}
+{%- from slspath + '/map.jinja' import consul with context -%}
 
 consul-dep-unzip:
   pkg.installed:
@@ -17,7 +17,8 @@ consul-group:
 consul-user:
   user.present:
     - name: {{ consul.user }}
-    - gid: {{ consul.group }}
+    - groups:
+      - {{ consul.group }}
     - createhome: False
     - system: True
     - require:
@@ -29,13 +30,15 @@ consul-config-dir:
     - name: /etc/consul.d
     - user: {{ consul.user }}
     - group: {{ consul.group }}
+    - mode: 0750
 
 consul-data-dir:
   file.directory:
     - name: {{ consul.config.data_dir }}
-    - user: consul
-    - group: consul
     - makedirs: True
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
+    - mode: 0750
 
 # Install agent
 consul-download:


### PR DESCRIPTION
This is a follow-up PR for #23.

It fixes permissions on a filesystem for Consul JSON configuration file and data directory. It should be accessible only for user and group under which Consul agent is supposed to be runt.

@AAbouZaid, please review.