### PR TITLE
Set datata dir as home dir for new Consul user

### DIFF
--- a/consul/install.sls
+++ b/consul/install.sls
@@ -19,6 +19,7 @@ consul-user:
     - name: {{ consul.user }}
     - groups:
       - {{ consul.group }}
+    - home: {{ salt['user.info'](consul.user)['home']|default(consul.config.data_dir) }}
     - createhome: False
     - system: True
     - require:


### PR DESCRIPTION
This PR makes sure that the home directory for newly created Consul user account will be set to configured data directory. This would simplify debugging (and remove annoying console warnings) if you need to run shell with same privileges as Consul has.

If you configure existing user account to run the service with, home directory will not be changed.

@AAbouZaid , please review. Thank you in advance!