### PR TITLE
Allow adding additional node tags to nodes

### DIFF
--- a/consul/service.sls
+++ b/consul/service.sls
@@ -17,7 +17,7 @@ consul-init-env:
 
 consul-init-file:
   file.managed:
-    {%- if salt['test.provider']('service') == 'systemd' %}
+    {%- if salt['test.provider']('service').startswith('systemd') %}
     - source: salt://{{ slspath }}/files/consul.service
     - name: /etc/systemd/system/consul.service
     - template: jinja


### PR DESCRIPTION
This PR allows adding tags to Prometheus node-exporter services by adding a `node_tags` dictionary to the pillars. These tags can be used for dynamic relabeling in Prometheus.

Example:

```
node_tags:
  abc: def
  uvw: xzy
```

will add the following `tags` definition to the service definition of a the node-exporter:

```
"tags": ["abc:def", "uvw:xzy"]
```

Existing tag definitions are retained and the new tags are only appended.

The incentive is that adding a global `node_tags` pillar to a host (and extending it in subsequent pillar files) is more flexible than having to define all tags inside the `consul` pillar. This way I don't need to encode (redundant) external knowledge into the service definition and I can better reuse the tags in other states, hence I find it generally more useful. Perhaps you do, too.