### PR TITLE
(doc) show more config variables in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -6,6 +6,9 @@ consul:
   user: consul
   group: consul
 
+  version: 0.7.0
+  download_host: releases.hashicorp.com
+
   config:
     server: True
     bind_addr: 0.0.0.0
@@ -21,6 +24,10 @@ consul:
     retry_join:
       - 1.1.1.1
       - 2.2.2.2
+
+    ui: true
+    log_level: info
+    data_dir: /var/consul
 
   register:
     - name: Redis


### PR DESCRIPTION
Newcomers tend to consult (read: copy) the pillar.example when constructing their test trials.

Some additional info on available options can only help.

(I'll submit a separate PR to bump the default version from 0.7 to 1.2.1/latest)