### PR TITLE
bump consul version default to 1.2.1

### DIFF
--- a/consul/defaults.yaml
+++ b/consul/defaults.yaml
@@ -1,5 +1,5 @@
 consul:
-  version: 0.7.0
+  version: 1.2.1
   download_host: releases.hashicorp.com
 
   service: false


### PR DESCRIPTION
Changes the default Consul version to 1.2.1 from 0.7.0 (many significant changes since 0.7.0) 