### PR TITLE
Fix systemd detection and allow disabling the service

### DIFF
--- a/consul/init.sls
+++ b/consul/init.sls
@@ -1,6 +1,9 @@
+{%- if pillar.get('consul', {}).get('enabled', True) %}
 {% from slspath+"/map.jinja" import consul with context %}
 
 include:
   - {{ slspath }}.install
   - {{ slspath }}.config
   - {{ slspath }}.service
+
+{%- endif %}

--- a/consul/service.sls
+++ b/consul/service.sls
@@ -17,7 +17,7 @@ consul-init-env:
 
 consul-init-file:
   file.managed:
-    {%- if salt['test.provider']('service') == 'systemd' %}
+    {%- if salt['test.provider']('service').startswith('systemd') %}
     - source: salt://{{ slspath }}/files/consul.service
     - name: /etc/systemd/system/consul.service
     - template: jinja


### PR DESCRIPTION
Fixes systemd detection on some systems, which don't expose their systemd service provider as `"systemd`".

Background: we have quite a large and heterogeneous pool of managed workstations and some report `"systemd.cpython-35"` as service provider.

Further, I added an `enabled` flag which can be set to `False` to disable the consul state altogether. This is standard for many Salt formulae. For compatibility reasons I set it to `True` by default, although I'd generally prefer `False`.