### PR TITLE
Allow UID & GID to be setup for consul service user & group

### DIFF
--- a/consul/defaults.yaml
+++ b/consul/defaults.yaml
@@ -5,7 +5,9 @@ consul:
   service: false
 
   user: consul
+  user_uid:
   group: consul
+  group_gid:
 
   config:
     server: false

--- a/consul/install.sls
+++ b/consul/install.sls
@@ -13,10 +13,16 @@ consul-bin-dir:
 consul-group:
   group.present:
     - name: {{ consul.group }}
+    {% if consul.get('group_gid', None) != None -%}
+    - gid: {{ consul.group_gid }}
+    {%- endif %}
 
 consul-user:
   user.present:
     - name: {{ consul.user }}
+    {% if consul.get('user_uid', None) != None -%}
+    - uid: {{ consul.user_uid }}
+    {% endif -%}
     - groups:
       - {{ consul.group }}
     - home: {{ salt['user.info'](consul.user)['home']|default(consul.config.data_dir) }}


### PR DESCRIPTION
In my environment users should have the same uid & gid all along
the servers. This patch implement that.

The current behavior is maintained if consul.user_uid or
consul.group_gid is not defined in pillars.