### PR TITLE
Use cmd_check to validate config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.kitchen/
+Gemfile.lock

--- a/consul/config.sls
+++ b/consul/config.sls
@@ -11,13 +11,14 @@ consul-config:
     - context:
       content:
         {{ consul.config | yaml }}
-    - check_cmd: /usr/local/bin/consul validate
-    - tmp_ext: '.json'
     - require:
       - user: consul-user
     {%- if consul.service %}
+      - file: /usr/local/bin/consul
     - watch_in:
        - service: consul
+    - check_cmd: /usr/local/bin/consul validate
+    - tmp_ext: '.json'
     {%- endif %}
 
 {% for script in consul.scripts %}
@@ -44,11 +45,13 @@ consul-script-config:
       content:
         services:
           {{ consul.register | yaml }}
-    - check_cmd: /usr/local/bin/consul validate /etc/consul.d/config.json
-    - tmp_ext: '.json'
     - require:
       - user: consul-user
     {% if consul.service != False %}
+      - file: /usr/local/bin/consul
+      - file: /etc/consul.d/config.json
     - watch_in:
        - service: consul
+    - check_cmd: /usr/local/bin/consul validate /etc/consul.d/config.json
+    - tmp_ext: '.json'
     {% endif %}

--- a/consul/config.sls
+++ b/consul/config.sls
@@ -1,13 +1,18 @@
 {%- from slspath + '/map.jinja' import consul with context -%}
 
 consul-config:
-  file.serialize:
+  file.managed:
     - name: /etc/consul.d/config.json
-    - formatter: json
-    - dataset: {{ consul.config }}
     - user: {{ consul.user }}
     - group: {{ consul.group }}
     - mode: 0640
+    - source: salt://{{ slspath }}/files/template.json.jinja
+    - template: jinja
+    - context:
+      content:
+        {{ consul.config | yaml }}
+    - check_cmd: /usr/local/bin/consul validate
+    - tmp_ext: '.json'
     - require:
       - user: consul-user
     {%- if consul.service %}
@@ -28,16 +33,22 @@ consul-script-install-{{ loop.index }}:
 {% endfor %}
 
 consul-script-config:
-  file.serialize:
+  file.managed:
     - name: /etc/consul.d/services.json
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
+    - mode: 0640
+    - source: salt://{{ slspath }}/files/template.json.jinja
+    - template: jinja
+    - context:
+      content:
+        services:
+          {{ consul.register | yaml }}
+    - check_cmd: /usr/local/bin/consul validate /etc/consul.d/config.json
+    - tmp_ext: '.json'
+    - require:
+      - user: consul-user
     {% if consul.service != False %}
     - watch_in:
        - service: consul
     {% endif %}
-    - user: {{ consul.user }}
-    - group: {{ consul.group }}
-    - require:
-      - user: consul-user
-    - formatter: json
-    - dataset:
-        services: {{ consul.register }}

--- a/consul/files/template.json.jinja
+++ b/consul/files/template.json.jinja
@@ -1,0 +1,1 @@
+{{ content | tojson(indent=2) }}

--- a/pillar.example
+++ b/pillar.example
@@ -6,7 +6,7 @@ consul:
   user: consul
   group: consul
 
-  version: 0.7.0
+  version: 1.2.0
   download_host: releases.hashicorp.com
 
   config:


### PR DESCRIPTION
In some case I have an error in config file. State detect a change, restart services, restart fail. It's bad.

Soo, I rewrite the resources to use `file.managed` allowed `cmd_check`.

It works as:
```
  Name: /usr/local/bin/consul - Function: file.symlink - Result: Clean Started: - 14:26:24.064532 Duration: 2.029 ms
----------
          ID: consul-config
    Function: file.managed
        Name: /etc/consul.d/config.json
      Result: False
     Comment: check_cmd execution failed
              Config validation failed: Error parsing /tmp/__salt.tmp.sQ8J8n.json: 1 error(s) occurred:

              * invalid config key asdf
     Started: 14:26:24.067033
    Duration: 193.813 ms
     Changes:
  Name: /etc/consul.d/services.json - Function: file.managed - Result: Clean Started: - 14:26:24.261664 Duration: 68.404 ms
  Name: /etc/default/consul - Function: file.managed - Result: Clean Started: - 14:26:24.330434 Duration: 13.754 ms
  Name: /etc/systemd/system/consul.service - Function: file.managed - Result: Clean Started: - 14:26:24.344581 Duration: 38.792 ms
----------
          ID: consul-service
    Function: service.running
        Name: consul
      Result: False
     Comment: One or more requisite failed: consul.config.consul-config
     Started: 14:26:24.386892
    Duration: 0.018 ms
     Changes:
```

Last think. I have an issue with whitespace and end of some lines :/
It's not a problem for Consul or Saltstack. Just for me when I open file with my vi doesn't like them and show me a "warning" (like my brain in fact :p ).