### PR TITLE
fix incompatible yaml renderer change in 2019.2.0

### DIFF
--- a/consul/config.sls
+++ b/consul/config.sls
@@ -4,7 +4,7 @@ consul-config:
   file.serialize:
     - name: /etc/consul.d/config.json
     - formatter: json
-    - dataset: {{ consul.config }}
+    - dataset_pillar: consul:config
     - user: {{ consul.user }}
     - group: {{ consul.group }}
     - mode: 0640
@@ -40,4 +40,4 @@ consul-script-config:
       - user: consul-user
     - formatter: json
     - dataset:
-        services: {{ consul.register }}
+        services: {{ consul.register | tojson }}

--- a/consul/config.sls
+++ b/consul/config.sls
@@ -40,4 +40,4 @@ consul-script-config:
       - user: consul-user
     - formatter: json
     - dataset:
-        services: {{ consul.register | tojson }}
+        services: {{ consul.register | json }}


### PR DESCRIPTION
see: https://docs.saltstack.com/en/develop/topics/releases/2019.2.0.html#non-backward-compatible-change-to-yaml-renderer