### PR TITLE
fix: use the dict built in map.jinja that includes the defaults

### DIFF
--- a/consul/config.sls
+++ b/consul/config.sls
@@ -4,7 +4,7 @@ consul-config:
   file.serialize:
     - name: /etc/consul.d/config.json
     - formatter: json
-    - dataset_pillar: consul:config
+    - dataset: {{ consul.config | json }}
     - user: {{ consul.user }}
     - group: {{ consul.group }}
     - mode: 0640


### PR DESCRIPTION
I inadvertently introduced this bug in an earlier commit.