### PR TITLE
Add node_id_hook property to allow script-based node IDs

### DIFF
--- a/consul/install.sls
+++ b/consul/install.sls
@@ -47,6 +47,15 @@ consul-data-dir:
     - group: {{ consul.group }}
     - mode: 0750
 
+{%- if consul.get('node_id_hook') %}
+consul-node-id-hook:
+  cmd.run:
+    - name: {{ consul.node_id_hook }} > {{ consul.config.data_dir }}/node-id
+    - user: {{ consul.user }}
+    - group: {{ consul.group }}
+    - creates: {{ consul.config.data_dir }}/node-id
+{%- endif %}
+
 # Install agent
 consul-download:
   file.managed:

--- a/pillar.example
+++ b/pillar.example
@@ -9,6 +9,8 @@ consul:
   version: 0.7.0
   download_host: releases.hashicorp.com
 
+  node_id_hook: echo -n {{ grains.fqdn }} | sha256sum | python -c 'import sys; s = next(sys.stdin); sys.stdout.write("{}-{}-{}-{}-{}".format(s[0:8], s[8:12], s[12:16], s[16:20], s[20:32]))'
+
   config:
     server: True
     bind_addr: 0.0.0.0


### PR DESCRIPTION
This adds a property `node_id_hook` which allows to use arbitrary scripts to generate a static node ID. This is particularly useful for deployment in Docker containers or on diskless servers.