### PR TITLE
Replace deprecated ui config option with ui_config

### DIFF
--- a/consul/defaults.yaml
+++ b/consul/defaults.yaml
@@ -1,6 +1,6 @@
 ---
 consul:
-  version: 1.3.0
+  version: 1.9.0
   download_host: releases.hashicorp.com
 
   service: false
@@ -14,7 +14,8 @@ consul:
     server: false
     bind_addr: 0.0.0.0
     data_dir: /var/consul
-    ui: true
+    ui_config:
+      enabled: true
     enable_debug: false
     log_level: info
     encrypt: ""

--- a/pillar.example
+++ b/pillar.example
@@ -9,7 +9,7 @@ consul:
   user: consul
   group: consul
 
-  version: 0.7.0
+  version: 1.9.0
   download_host: releases.hashicorp.com
 
   config:
@@ -28,7 +28,8 @@ consul:
       - 1.1.1.1
       - 2.2.2.2
 
-    ui: true
+    ui_config:
+      enabled: true
     log_level: info
     data_dir: /var/consul
 


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->
Consul 1.9.0 deprecates the `ui` config option, which is now replaced by `ui_config.enabled`.

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

Yes. This cannot be updated in a non-breaking fashion, but I chose the least disruptive route.

If both `ui` and `ui_config.enabled` are set , `ui_config` takes precedence. Hence, my change may enable the UI on machines which had previously set `ui` to `false`. This is arguably better than defaulting to `false`, which would disable the UI where it is supposed to be enabled.

Removing the option entirely breaks similarly if users rely on the formula defaults, since Consul's default is `false` and the formula's default used to be `true`.

The only other way to break less would be to set both options, but then users would also have override both (which is not obvious and very annoying) and there would still be no way forward to when Consul actually removes the deprecated option.

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->
The pillar `defaults.yaml` set `ui: true` by default, which adds redundant and potentially contradicting configuration to Consul agents with the new `ui_config` option.

I also updated the ancient default Consul version to 1.9.0 appropriately.

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

